### PR TITLE
Make `threaded` a property of Context

### DIFF
--- a/resources/library/effects/still.glsl
+++ b/resources/library/effects/still.glsl
@@ -1,5 +1,5 @@
 #property description Stick chunks to the screen
-#propert frequency 1
+#property frequency 1
 
 void main(void) {
     vec4 hold = texture(iChannel[1], uv);

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -10,10 +10,15 @@ Context::Context(bool threaded)
     , m_timebase(nullptr)
     , m_openGLWorkerContext(nullptr)
 {
+    m_threaded = threaded;
     m_openGLWorkerContext = new OpenGLWorkerContext(threaded);
 
     m_timebase = new Timebase();
     m_audio = new Audio(m_timebase);
+}
+
+bool Context::threaded() {
+    return m_threaded;
 }
 
 Audio *Context::audio() {

--- a/src/Context.h
+++ b/src/Context.h
@@ -20,11 +20,13 @@ public:
     Context(bool threaded=true);
    ~Context();
 
+    bool threaded();
     Audio *audio();
     Timebase *timebase();
     OpenGLWorkerContext *openGLWorkerContext();
 
 protected:
+    bool m_threaded;
     Audio *m_audio;
     Timebase *m_timebase;
     OpenGLWorkerContext *m_openGLWorkerContext;

--- a/src/MovieNode.cpp
+++ b/src/MovieNode.cpp
@@ -10,13 +10,14 @@
 #include <array>
 #include <QJsonObject>
 #include "Paths.h"
+#include "Context.h"
 #include "OpenGLWorkerContext.h"
 #include "OpenGLWorker.h"
 
 MovieNode::MovieNode(Context *context, QString file, QString name)
     : VideoNode(new MovieNodePrivate(context))
 {
-    d()->m_openGLWorkerContext = new OpenGLWorkerContext();
+    d()->m_openGLWorkerContext = new OpenGLWorkerContext(context->threaded());
     d()->m_openGLWorker = QSharedPointer<MovieNodeOpenGLWorker>(new MovieNodeOpenGLWorker(*this), &QObject::deleteLater);
     connect(d()->m_openGLWorker.data(), &QObject::destroyed, d()->m_openGLWorkerContext, &QObject::deleteLater);
 

--- a/src/SelfTimedReadBackOutputNode.cpp
+++ b/src/SelfTimedReadBackOutputNode.cpp
@@ -41,25 +41,21 @@ SelfTimedReadBackOutputNode::SelfTimedReadBackOutputNode(QSharedPointer<SelfTime
 }
 
 void SelfTimedReadBackOutputNode::start() {
-    Q_ASSERT(QThread::currentThread() == thread());
     auto result = QMetaObject::invokeMethod(d()->m_worker.data(), "start");
     Q_ASSERT(result);
 }
 
 void SelfTimedReadBackOutputNode::stop() {
-    Q_ASSERT(QThread::currentThread() == thread());
     auto result = QMetaObject::invokeMethod(d()->m_worker.data(), "stop");
     Q_ASSERT(result);
 }
 
 void SelfTimedReadBackOutputNode::setInterval(long msec) {
-    Q_ASSERT(QThread::currentThread() == thread());
     auto result = QMetaObject::invokeMethod(d()->m_worker.data(), "setInterval", Q_ARG(long, msec));
     Q_ASSERT(result);
 }
 
 void SelfTimedReadBackOutputNode::force() {
-    Q_ASSERT(QThread::currentThread() == thread());
     auto result = QMetaObject::invokeMethod(d()->m_worker.data(), "onTimeout");
     Q_ASSERT(result);
 }

--- a/src/SelfTimedReadBackOutputNode.cpp
+++ b/src/SelfTimedReadBackOutputNode.cpp
@@ -41,21 +41,25 @@ SelfTimedReadBackOutputNode::SelfTimedReadBackOutputNode(QSharedPointer<SelfTime
 }
 
 void SelfTimedReadBackOutputNode::start() {
+    Q_ASSERT(QThread::currentThread() == thread());
     auto result = QMetaObject::invokeMethod(d()->m_worker.data(), "start");
     Q_ASSERT(result);
 }
 
 void SelfTimedReadBackOutputNode::stop() {
+    Q_ASSERT(QThread::currentThread() == thread());
     auto result = QMetaObject::invokeMethod(d()->m_worker.data(), "stop");
     Q_ASSERT(result);
 }
 
 void SelfTimedReadBackOutputNode::setInterval(long msec) {
+    Q_ASSERT(QThread::currentThread() == thread());
     auto result = QMetaObject::invokeMethod(d()->m_worker.data(), "setInterval", Q_ARG(long, msec));
     Q_ASSERT(result);
 }
 
 void SelfTimedReadBackOutputNode::force() {
+    Q_ASSERT(QThread::currentThread() == thread());
     auto result = QMetaObject::invokeMethod(d()->m_worker.data(), "onTimeout");
     Q_ASSERT(result);
 }
@@ -83,6 +87,7 @@ STRBONOpenGLWorker::STRBONOpenGLWorker(SelfTimedReadBackOutputNode p)
 }
 
 QSharedPointer<QOpenGLShaderProgram> STRBONOpenGLWorker::loadBlitShader() {
+    Q_ASSERT(QThread::currentThread() == thread());
     auto vertexString = QString{
         "#version 150\n"
         "out vec2 uv;\n"
@@ -120,8 +125,9 @@ QSharedPointer<QOpenGLShaderProgram> STRBONOpenGLWorker::loadBlitShader() {
 }
 
 void STRBONOpenGLWorker::initialize(QSize size) {
-    makeCurrent();
     Q_ASSERT(QThread::currentThread() == thread());
+
+    makeCurrent();
     m_shader = loadBlitShader();
     if (m_shader.isNull()) return;
 
@@ -139,24 +145,29 @@ void STRBONOpenGLWorker::initialize(QSize size) {
 }
 
 void STRBONOpenGLWorker::setInterval(long msec) {
+    Q_ASSERT(QThread::currentThread() == thread());
     if (m_timer == nullptr) {
         qWarning() << "Node not ready, ignoring setInterval";
         return;
     }
+
     m_timer->setInterval(msec);
 }
 
 void STRBONOpenGLWorker::start() {
+    Q_ASSERT(QThread::currentThread() == thread());
     if (m_timer == nullptr) {
         qWarning() << "Node not ready, ignoring start";
         return;
     }
+
     m_timer->start();
 }
 
 void STRBONOpenGLWorker::stop() {
+    Q_ASSERT(QThread::currentThread() == thread());
     if (m_timer == nullptr) {
-        qWarning() << "Node not ready, ignoring start";
+        qWarning() << "Node not ready, ignoring stop";
         return;
     }
     m_timer->stop();


### PR DESCRIPTION
* Context, at creation, is set to either threaded (e.g. for GUI) or unthreaded (e.g. for CLI)
* When new `OpenGLWorkerContext`s are created, they use this global threadedness value