### PR TITLE
Bring back AutoDJ, with freezing nodes to prevent the user from interfering

### DIFF
--- a/resources/qml/AutoDJ.qml
+++ b/resources/qml/AutoDJ.qml
@@ -1,0 +1,281 @@
+import QtQuick 2.7
+import QtQuick.Layouts 1.2
+import QtQuick.Controls 1.4
+import QtQuick.Controls.Styles 1.0
+import radiance 1.0
+import "."
+
+RowLayout {
+    id: autoDJ;
+
+    property var context;
+    property var t;
+
+    // Setup for working with full 2D video art (e.g. projector, livestream)
+    property var choices: [
+        // Base: something that has color or form
+        ["cyan", "dwwave", "fire", "heart", "pink", "purple", "wave", "wwave", "yellow", "vu", "oscope", "count", "random", "rekt", "gay"],
+
+        // Intensitfy: add distortions and high-pass
+        // Always set to 0.5 frequency
+        ["edge", "pixelate", "delace", "depolar", "droste", "droste", "flippy", "fractalzoom", "glitch", "halftone", "kaleidoscope", "lathe", "litebrite", "lorenz", "polygon", "uvmapself", "strange", "cga1", "crack", "outline", "projector"],
+
+        // Colorize
+        ["sethue", "greenaway", "smoky", "chansep", "threedee", "yuvposter", "yuvrot", "yuvsat", "blowout", "cedge", "gamma", "rainblur", "resat", "rjump", "rsheen", "saturate", "yuvblur", "yuvchansep"],
+
+        // Motion
+        // Always set to 0.5 frequency
+        ["fly", "tunnel", "warble", "flowing", "flow", "fractalzoom", "life", "scramble", "tesselate", "bespeckle", "bespecklep", "coin", "shake", "solitare", "id", "id", "id"],
+
+        // Low-pass
+        ["lpf", "diodelpf", "crt", "posterize", "melt", "life", "smoky", "speckle", "stripey", "rolling", "still", "swipe"],
+        ["rekt"],
+        ["bespeckle"],
+        ["fly"],
+        ["rekt"],
+        ["rekt"],
+        ["rekt"],
+        ["rekt"],
+        ["rekt"],
+        ["rekt"],
+        ["rekt"],
+        ["rekt"],
+        ["rekt"],
+        ["rekt"],
+    ];
+    /*
+    // Setup for working with light strips and pixels
+    // May need to follow up with an lpf, smooth, no, etc. 
+    property var choices: [
+        // Base: something with *color*, can be static
+        ["cyan", "fire", "fireball", "heart", "purple", "wave", "yellow", "vu", "test", "gay", "rekt", "rekt", "rekt", "smoke", "stripes", "yuvmapid", "uvmapid"],
+
+        // Simple motion
+        // Always set to 0.5 frequency
+        ["warble", "flowing", "flow", "fractalzoom", "flippy", "scramble", "bespeckle", "bespecklep", "shake", "id"],
+
+        // Colorize
+        ["sethue", "greenaway", "yuvposter", "yuvrot", "yuvsat", "blowout", "cedge", "gamma", "rainblur", "resat", "rjump", "rsheen", "saturate", "yuvblur", "yuvchansep"],
+
+        // Simple motion
+        // Always set to 0.5 frequency
+        ["warble", "flowing", "flow", "fractalzoom", "flippy", "scramble", "bespeckle", "bespecklep", "shake", "id"],
+
+        // Colorize
+        ["sethue", "greenaway", "yuvposter", "yuvrot", "yuvsat", "blowout", "cedge", "gamma", "rainblur", "resat", "rjump", "rsheen", "saturate", "yuvblur", "yuvchansep"],
+
+        // Low-pass
+        ["lpf", "diodelpf", "posterize", "melt", "speckle", "stripey", "rolling", "still", "swipe", "kmeans"]
+    ];
+    */
+
+    function makeVideoNode(index) {
+        var choice = choices[index][Math.floor(Math.random() * choices[index].length)];
+        var vn = registry.deserialize(context, 
+        {
+            "file": "effects/" + choice + ".glsl",
+            "type": "EffectNode"
+        });
+        if (index == 1 || index == 3) {
+            if (Math.random() < 0.1) vn.frequency = 1.0;
+            else if (Math.random() < 0.7) vn.frequency = 0.5;
+            else vn.frequency = 0.25;
+        }
+        vn.setFrozenOutput(true);
+        vn.setFrozenInput(true);
+        vn.setFrozenParameters(true);
+        model.addVideoNode(vn);
+        return vn;
+    }
+
+    function getOrMakePlaceholders(prefix) {
+        var head = null;
+        var tail = null;
+        var headRole = prefix + " Head";
+        var tailRole = prefix + " Tail";
+        for (var i = 0; i < model.vertices.length; i++) {
+            if (model.vertices[i].role == headRole)
+                head = model.vertices[i];
+            else if (model.vertices[i].role == tailRole)
+                tail = model.vertices[i];
+        }
+        
+        if (!head || !tail) {
+            if (head) {
+                model.removeVideoNode(head);
+            }
+            if (tail) {
+                model.removeVideoNode(tail);
+            }
+            head = makePlaceholder(headRole);
+            tail = makePlaceholder(tailRole);
+        }
+        head.setFrozenOutput(true);
+        tail.setFrozenInput(true);
+
+        var headDescendants = model.qmlDescendants(head);
+        if (headDescendants.includes(tail)) {
+            var tailAncestors = model.qmlAncestors(tail);
+            for (var i = 0; i < headDescendants.length; i++) {
+                var node = headDescendants[i];
+                if (node != tail && tailAncestors.includes(node)) {
+                    model.removeVideoNode(node);
+                }
+            }
+        } else {
+            for (var i = 0; i < model.edges.length; i++) {
+                var edge = model.edges[i];
+                if (edge.fromVertex == head) {
+                    model.removeEdge(edge.fromVertex, edge.toVertex, edge.toInput);
+                } else if (edge.toVertex == tail) {
+                    model.removeEdge(edge.fromVertex, edge.toVertex, edge.toInput);
+                }
+            }
+        }
+
+        model.flush();
+        return [head, tail];
+    }
+
+    function makePlaceholder(role) {
+        var vn = registry.deserialize(context, 
+        {
+            "type": "PlaceholderNode",
+            "role": role,
+        });
+        model.addVideoNode(vn);
+        return vn;
+    }
+
+    function randomIntensity() {
+        return 0.4 + Math.random() * 0.5;
+    }
+
+    function randomIndex() {
+        // Usually return 0
+        if (Math.random() < 0.4) return 0;
+        return Math.floor(Math.random() * choices.length);
+    }
+
+    function timer() {
+        return Qt.createQmlObject("import QtQuick 2.0; Timer {}", autoDJ);
+    }
+
+    function waitShortTime(cb) {
+        var t = timer();
+        t.interval = 10;
+        t.repeat = false;
+        t.triggered.connect(function () {
+            if (running.checked) cb();
+        });
+        t.start();
+    }
+
+    function waitRandomTime(cb) {
+        this.t = timer();
+        t.interval = 100; // Math.floor(1000 + Math.random() * 5000);
+        t.repeat = false;
+        t.triggered.connect(function () {
+            if (running.checked) cb();
+        });
+        t.start();
+    }
+
+    function startAutoDJ() {
+        // https://tc39.github.io/ecma262/#sec-array.prototype.includes
+        if (!Array.prototype.includes) {
+        Object.defineProperty(Array.prototype, 'includes', { value: function(valueToFind, fromIndex) {
+            if (this == null) { throw new TypeError('"this" is null or not defined'); }
+            var o = Object(this);
+            var len = o.length >>> 0;
+            if (len === 0) { return false; }
+            var n = fromIndex | 0;
+            var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+            function sameValueZero(x, y) { return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y)); }
+            while (k < len) { if (sameValueZero(o[k], valueToFind)) { return true; } k++; }
+            return false;
+            } });
+        }
+
+        this.t = null;
+        console.log("Start!");
+        var placeholders = getOrMakePlaceholders('AutoDJ');
+        var head = placeholders[0];
+        var tail = placeholders[1];
+        var vns = [];
+
+        function getNode(i) {
+            if (i < 0) return head;
+            if (i >= choices.length) return tail;
+            return vns[i];
+        }
+
+        for (var i=0; i<choices.length; i++) {
+            vns.push(makeVideoNode(i));
+        }
+        for (var i=0; i<choices.length; i++) {
+            vns[i].intensity = randomIntensity();
+        }
+        for (var i=0; i<=choices.length; i++) {
+            model.addEdge(getNode(i - 1), getNode(i), 0);
+        }
+        model.flush();
+
+        function replace(i) {
+            var newVN = makeVideoNode(i);
+            model.addEdge(vns[i], newVN, 0);
+            model.addEdge(newVN, getNode(i+1), 0);
+            model.flush();
+            function onFadeDone() {
+                model.addEdge(getNode(i - 1), newVN, 0);
+                model.removeVideoNode(vns[i]);
+                vns[i] = newVN;
+                model.flush();
+                waitRandomTime(function () {replace(randomIndex())});
+            }
+            fade(vns[i], newVN, vns[i].intensity, randomIntensity(), 0., onFadeDone);
+        }
+
+        function fade(from, to, start, end, fraction, cb) {
+            if (fraction > 1) fraction = 1;
+            from.intensity = start * (1. - fraction);
+            to.intensity = end * fraction;
+                cb();
+        }
+
+        waitRandomTime(function() {
+          for (var i = 0; i < choices.length; i++) {
+            replace(i);
+          }
+          });
+    }
+
+    function stopAutoDJ() {
+        this.t.stop();
+        var nodes = model.vertices;
+        for (var i = 0; i < nodes.length; i++) {
+            nodes[i].setFrozenOutput(false);
+            nodes[i].setFrozenInput(false);
+            nodes[i].setFrozenParameters(false);
+        }
+        console.log("Stop!", this.t);
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+
+        CheckBox {
+            id: running;
+            text: "Enable Auto DJ"
+
+            onCheckedChanged: {
+                if (checked) {
+                    startAutoDJ();
+                } else {
+                    stopAutoDJ();
+                }
+            }
+        }
+    }
+}

--- a/resources/qml/AutoDJ.qml
+++ b/resources/qml/AutoDJ.qml
@@ -25,23 +25,10 @@ RowLayout {
 
         // Motion
         // Always set to 0.5 frequency
-        ["fly", "tunnel", "warble", "flowing", "flow", "fractalzoom", "life", "scramble", "tesselate", "bespeckle", "bespecklep", "coin", "shake", "solitare", "id", "id", "id"],
+        ["fly", "tunnel", "warble", "flowing", "flow", "fractalzoom", "life", "scramble", "tesselate", "bespeckle", "bespecklep", "coin", "shake", "solitaire", "id", "id", "id"],
 
         // Low-pass
         ["lpf", "diodelpf", "crt", "posterize", "melt", "life", "smoky", "speckle", "stripey", "rolling", "still", "swipe"],
-        ["rekt"],
-        ["bespeckle"],
-        ["fly"],
-        ["rekt"],
-        ["rekt"],
-        ["rekt"],
-        ["rekt"],
-        ["rekt"],
-        ["rekt"],
-        ["rekt"],
-        ["rekt"],
-        ["rekt"],
-        ["rekt"],
     ];
     /*
     // Setup for working with light strips and pixels
@@ -173,7 +160,7 @@ RowLayout {
 
     function waitRandomTime(cb) {
         this.t = timer();
-        t.interval = 100; // Math.floor(1000 + Math.random() * 5000);
+        t.interval = Math.floor(1000 + Math.random() * 5000);
         t.repeat = false;
         t.triggered.connect(function () {
             if (running.checked) cb();
@@ -198,7 +185,7 @@ RowLayout {
         }
 
         this.t = null;
-        console.log("Start!");
+        console.log("Starting AutoDJ");
         var placeholders = getOrMakePlaceholders('AutoDJ');
         var head = placeholders[0];
         var tail = placeholders[1];
@@ -240,14 +227,16 @@ RowLayout {
             if (fraction > 1) fraction = 1;
             from.intensity = start * (1. - fraction);
             to.intensity = end * fraction;
+            if (fraction == 1) {
                 cb();
+            } else {
+                waitShortTime(function() {fade(from, to, start, end, fraction + 0.01, cb)});
+            }
         }
 
         waitRandomTime(function() {
-          for (var i = 0; i < choices.length; i++) {
-            replace(i);
-          }
-          });
+            replace(randomIndex());
+        });
     }
 
     function stopAutoDJ() {
@@ -258,7 +247,7 @@ RowLayout {
             nodes[i].setFrozenInput(false);
             nodes[i].setFrozenParameters(false);
         }
-        console.log("Stop!", this.t);
+        console.log("Stopping AutoDJ", this.t);
     }
 
     ColumnLayout {

--- a/resources/qml/EffectNodeTile.qml
+++ b/resources/qml/EffectNodeTile.qml
@@ -22,7 +22,7 @@ VideoNodeTile {
     Connections {
         target: videoNode
         onIntensityChanged: {
-            slider.value = intensity;
+            slider.value = videoNode.intensity;
         }
         onFrequencyChanged: {
             frequencyCombo.value = frequency;

--- a/resources/qml/RadianceTile.qml
+++ b/resources/qml/RadianceTile.qml
@@ -6,6 +6,7 @@ import "."
 
 Item {
     property real oversample: 1
+    property bool frozen: false;
     property alias inputArrows: canvas.inputArrows
     property alias outputArrow: canvas.outputArrow
     property alias arrowWidth: canvas.arrowWidth
@@ -30,7 +31,7 @@ Item {
         property bool selected: false;
         property bool highlight: false;
         property color bottomColor: selected ? RadianceStyle.tileBackgroundHighlightColor : RadianceStyle.tileBackgroundColor;
-        property color topColor: Qt.lighter(bottomColor, 1.75);
+        property color topColor: Qt.lighter(bottomColor, frozen ? 3.5 : 1.75);
         property real borderWidth: 1;
         property color borderColor: highlight ? RadianceStyle.tileLineHighlightColor : RadianceStyle.tileLineColor;
         property int padding: 3;

--- a/resources/qml/SettingsWidget.qml
+++ b/resources/qml/SettingsWidget.qml
@@ -65,6 +65,10 @@ Item {
             }
         }
 
+        AutoDJ {
+            context: defaultContext
+        }
+
         Item {
             Layout.fillHeight: true
         }

--- a/resources/qml/VideoNodeTile.qml
+++ b/resources/qml/VideoNodeTile.qml
@@ -283,7 +283,7 @@ BaseVideoNodeTile {
         }
 
         drag.onActiveChanged: {
-            view.addToSelection([tile]);
+            view.ensureSelected([tile]);
             if (drag.active) {
                 dragLift();
             } else {

--- a/resources/qml/VideoNodeTile.qml
+++ b/resources/qml/VideoNodeTile.qml
@@ -189,13 +189,21 @@ BaseVideoNodeTile {
             if (ccs.length == 0) break;
             var deleteCC = ccs[0];
 
-            // Step 1. Delete nodes
+            // Step 1. Check if any nodes are frozen, then do nothing
+            for (var i=0; i<deleteCC.vertices.length; i++) {
+                var e = deleteCC.vertices[i];
+                if (e.frozenInput || e.frozenOutput || e.frozenParameters) {
+                    return;
+                }
+            }
+
+            // Step 2. Delete nodes
             for (var i=0; i<deleteCC.vertices.length; i++) {
                 var e = deleteCC.vertices[i];
                 model.removeVideoNode(e);
             }
 
-            // Step 2. Stitch the surrounding blocks back together
+            // Step 3. Stitch the surrounding blocks back together
             if (deleteCC.inputEdges.length >= 1) {
                 for (var i=0; i<deleteCC.outputEdges.length; i++) {
                     var f = deleteCC.inputEdges[0];
@@ -254,8 +262,8 @@ BaseVideoNodeTile {
         view.parent.lastClickedTile = tile;
     }
 
-    KeyNavigation.tab: tab;
-    KeyNavigation.backtab: backtab;
+    KeyNavigation.tab: tab || null;
+    KeyNavigation.backtab: backtab || null;
 
     onActiveFocusChanged: {
         if (activeFocus) {
@@ -275,7 +283,7 @@ BaseVideoNodeTile {
         }
 
         drag.onActiveChanged: {
-            view.ensureSelected(tile);
+            view.addToSelection([tile]);
             if (drag.active) {
                 dragLift();
             } else {
@@ -293,6 +301,7 @@ BaseVideoNodeTile {
         focus: true;
         inputArrows: parent.inputArrows
         outputArrow: parent.outputArrow
+        frozen: videoNode && (videoNode.frozenInput || videoNode.frozenOutput);
     }
 
     Behavior on x {

--- a/src/BaseVideoNodeTile.cpp
+++ b/src/BaseVideoNodeTile.cpp
@@ -7,3 +7,7 @@ BaseVideoNodeTile::BaseVideoNodeTile(QQuickItem *p)
 }
 
 BaseVideoNodeTile::~BaseVideoNodeTile() = default;
+
+VideoNodeSP *BaseVideoNodeTile::videoNode() const {
+    return m_videoNode;
+}

--- a/src/BaseVideoNodeTile.h
+++ b/src/BaseVideoNodeTile.h
@@ -12,7 +12,7 @@ typedef QmlSharedPointer<VideoNode> VideoNodeSP;
 class BaseVideoNodeTile : public QQuickItem {
     Q_OBJECT
     Q_PROPERTY(ModelSP *model MEMBER m_model NOTIFY onModelChanged);
-    Q_PROPERTY(VideoNodeSP *videoNode MEMBER m_videoNode NOTIFY onVideoNodeChanged);
+    Q_PROPERTY(VideoNodeSP *videoNode MEMBER m_videoNode READ videoNode NOTIFY onVideoNodeChanged);
     Q_PROPERTY(QVariantList inputGridHeights MEMBER m_inputGridHeights NOTIFY onInputGridHeightsChanged);
     Q_PROPERTY(QVariantList inputHeights MEMBER m_inputHeights NOTIFY onInputHeightsChanged);
     Q_PROPERTY(int gridX MEMBER m_gridX NOTIFY onGridXChanged);
@@ -31,6 +31,8 @@ class BaseVideoNodeTile : public QQuickItem {
 public:
     BaseVideoNodeTile(QQuickItem *p = nullptr);
    ~BaseVideoNodeTile() override;
+
+   VideoNodeSP *videoNode() const;
 
 signals:
     void onModelChanged(ModelSP *model);

--- a/src/Model.h
+++ b/src/Model.h
@@ -106,11 +106,29 @@ public slots:
 
     // Returns a list of vertices that
     // are ancestors of the given node
-    QList<VideoNodeSP *> ancestors(VideoNodeSP *node);
+    QList<VideoNodeSP *> ancestors(VideoNodeSP *node) const;
 
     // Returns true if `parent`
     // is an ancestor of `child`
-    bool isAncestor(VideoNodeSP *parent, VideoNodeSP *child);
+    bool isAncestor(VideoNodeSP *parent, VideoNodeSP *child) const;
+
+    // Returns a list of vertices that
+    // are ancestors of the given node
+    // suitable for QML / Javascript
+    QVariantList qmlAncestors(VideoNodeSP *node) const;
+
+    // Returns a list of vertices, that
+    // are descendants of the given node
+    QList<VideoNodeSP *> descendants(VideoNodeSP *node) const;
+
+    // Returns true if `parent`
+    // is an descendant of `child`
+    bool isDescendant(VideoNodeSP *parent, VideoNodeSP *child) const;
+
+    // Returns a list of vertices that
+    // are ancestors of the given node
+    // suitable for QML / Javascript
+    QVariantList qmlDescendants(VideoNodeSP *node) const;
 
     // Chains are instances of the
     // model render pipeline

--- a/src/PlaceholderNode.cpp
+++ b/src/PlaceholderNode.cpp
@@ -12,6 +12,7 @@ PlaceholderNode::PlaceholderNode(Context *context, VideoNodeSP *wrapped)
 QJsonObject PlaceholderNode::serialize() {
     QJsonObject o = VideoNode::serialize();
     o["inputCount"] = inputCount();
+    o["role"] = role();
     // TODO serialize the wrapped VideoNode??
     return o;
 }
@@ -35,6 +36,23 @@ void PlaceholderNode::setWrappedVideoNode(VideoNodeSP *wrapped) {
 VideoNodeSP *PlaceholderNode::wrappedVideoNode() {
     QMutexLocker locker(&m_stateLock);
     return m_wrappedVideoNode;
+}
+
+QString PlaceholderNode::role() {
+    QMutexLocker locker(&m_stateLock);
+    return m_role;
+}
+
+void PlaceholderNode::setRole(QString value) {
+    bool changed = false;
+    {
+        QMutexLocker locker(&m_stateLock);
+        if (value != m_role) { 
+            m_role = value;
+            changed = true;
+        }
+    }
+    if (changed) emit roleChanged(value);
 }
 
 GLuint PlaceholderNode::paint(QSharedPointer<Chain> chain, QVector<GLuint> inputTextures) {
@@ -84,8 +102,14 @@ VideoNodeSP *PlaceholderNode::deserialize(Context *context, QJsonObject obj) {
         inputCount = inputCountValue.toInt();
     }
 
+    QString role;
+    if (obj.contains("role")) {
+        role = obj["role"].toString();
+    }
+
     auto node = new PlaceholderNodeSP(new PlaceholderNode(context));
     (*node)->setInputCount(inputCount);
+    (*node)->setRole(role);
     return node;
 }
 

--- a/src/PlaceholderNode.h
+++ b/src/PlaceholderNode.h
@@ -10,6 +10,7 @@ class PlaceholderNodePrivate;
 class PlaceholderNode
     : public VideoNode {
     Q_OBJECT
+    Q_PROPERTY(QString role READ role WRITE setRole NOTIFY roleChanged);
 
 public:
     PlaceholderNode(Context *context, VideoNodeSP *wrapped=nullptr);
@@ -47,12 +48,17 @@ public slots:
 
     void chainsEdited(QList<QSharedPointer<Chain>> added, QList<QSharedPointer<Chain>> removed) override;
 
+    QString role();
+    void setRole(QString value);
+
 signals:
     void wrappedVideoNodeChanged(VideoNodeSP *videoNode);
+    void roleChanged(QString value);
 
 protected:
     // m_wrappedVideoNode needs to be a VideoNodeSP since there are QML properties that fetch it
     VideoNodeSP *m_wrappedVideoNode{};
+    QString m_role;
 };
 
 typedef QmlSharedPointer<PlaceholderNode, VideoNodeSP> PlaceholderNodeSP;

--- a/src/VideoNode.cpp
+++ b/src/VideoNode.cpp
@@ -73,6 +73,57 @@ void VideoNode::setChains(QList<QSharedPointer<Chain>> chains) {
     }
 }
 
+bool VideoNode::frozenInput() {
+    QMutexLocker locker(&m_stateLock);
+    return m_frozenInput;
+}
+
+void VideoNode::setFrozenInput(bool value) {
+    bool changed = false;
+    {
+        QMutexLocker locker(&m_stateLock);
+        if (value != m_frozenInput) { 
+            m_frozenInput = value;
+            changed = true;
+        }
+    }
+    if (changed) emit frozenInputChanged(value);
+}
+
+bool VideoNode::frozenOutput() {
+    QMutexLocker locker(&m_stateLock);
+    return m_frozenOutput;
+}
+
+void VideoNode::setFrozenOutput(bool value) {
+    bool changed = false;
+    {
+        QMutexLocker locker(&m_stateLock);
+        if (value != m_frozenOutput) { 
+            m_frozenOutput = value;
+            changed = true;
+        }
+    }
+    if (changed) emit frozenOutputChanged(value);
+}
+
+bool VideoNode::frozenParameters() {
+    QMutexLocker locker(&m_stateLock);
+    return m_frozenParameters;
+}
+
+void VideoNode::setFrozenParameters(bool value) {
+    bool changed = false;
+    {
+        QMutexLocker locker(&m_stateLock);
+        if (value != m_frozenParameters) { 
+            m_frozenParameters = value;
+            changed = true;
+        }
+    }
+    if (changed) emit frozenParametersChanged(value);
+}
+
 Context *VideoNode::context() {
     // Not mutable, so no need to lock
     return m_context;

--- a/src/VideoNode.h
+++ b/src/VideoNode.h
@@ -24,6 +24,9 @@ class VideoNode
     Q_PROPERTY(Context *context READ context CONSTANT);
     Q_PROPERTY(int inputCount READ inputCount WRITE setInputCount NOTIFY inputCountChanged);
     Q_PROPERTY(NodeState nodeState READ nodeState WRITE setNodeState NOTIFY nodeStateChanged);
+    Q_PROPERTY(bool frozenInput READ frozenInput WRITE setFrozenInput NOTIFY frozenInputChanged);
+    Q_PROPERTY(bool frozenOutput READ frozenOutput WRITE setFrozenOutput NOTIFY frozenOutputChanged);
+    Q_PROPERTY(bool frozenParameters READ frozenParameters WRITE setFrozenParameters NOTIFY frozenParametersChanged);
 
 public:
     enum NodeState {
@@ -97,6 +100,21 @@ public slots:
     NodeState nodeState();
     void setNodeState(NodeState value);
 
+    // Freeze the input edge(s) to this VideoNode to discourage
+    // the user from changing them with the default UI
+    bool frozenInput();
+    void setFrozenInput(bool value);
+
+    // Freeze the output edge from this VideoNode to discourage
+    // the user from changing it with the default UI
+    bool frozenOutput();
+    void setFrozenOutput(bool value);
+
+    // Freeze the VideoNode-specific parameters (e.g. intensity)
+    // to discourage the user from changing them with the default UI
+    bool frozenParameters();
+    void setFrozenParameters(bool value);
+
 protected slots:
     // If your node does anything at all, you will need to override this method
     virtual void chainsEdited(QList<QSharedPointer<Chain>> added, QList<QSharedPointer<Chain>> removed);
@@ -121,6 +139,11 @@ signals:
     // Emitted when state changes
     void nodeStateChanged(NodeState value);
 
+    // Emitted when the frozen tstate changes
+    void frozenInputChanged(bool value);
+    void frozenOutputChanged(bool value);
+    void frozenParametersChanged(bool value);
+
 protected:
     VideoNode(Context *context);
 
@@ -130,6 +153,9 @@ protected:
     Context *m_context{};
     QWeakPointer<Model> m_lastModel;
     VideoNode::NodeState m_nodeState{VideoNode::Ready};
+    bool m_frozenInput{false};
+    bool m_frozenOutput{false};
+    bool m_frozenParameters{false};
 };
 
 QDebug operator<<(QDebug debug, const VideoNode &vn);

--- a/src/View.cpp
+++ b/src/View.cpp
@@ -443,7 +443,6 @@ void View::onGraphChanged() {
     qDeleteAll(m_dropAreas.begin(), m_dropAreas.end());
     m_dropAreas = dropAreas;
 
-    qInfo() << "refreshing selection";
     addToSelection(selection());
     selectionChanged();
 }
@@ -542,6 +541,21 @@ void View::toggleSelection(QVariantList _tiles) {
     if (allSelected) {
         removeFromSelection(tiles);
     } else {
+        addToSelection(tiles);
+    }
+}
+
+void View::ensureSelected(QVariantList _tiles) {
+    QVariantList tiles = frozenConnectedComponents(_tiles);
+    bool allSelected = true;
+    for (int i=0; i<tiles.count(); i++) {
+        auto tile = qvariant_cast<BaseVideoNodeTile*>(tiles[i]);
+        if (!m_selection.contains(tile)) {
+            allSelected = false;
+        }
+    }
+    if (!allSelected) {
+        m_selection.clear();
         addToSelection(tiles);
     }
 }

--- a/src/View.h
+++ b/src/View.h
@@ -33,14 +33,13 @@ public slots:
     void addToSelection(QVariantList tiles);
     void removeFromSelection(QVariantList tiles);
     void toggleSelection(QVariantList tiles);
-    void ensureSelected(BaseVideoNodeTile *tile);
     QVariantList selection();
 
     // Finds the connected components of the selection
     // Each connected component will have zero or more inputs and one output
     // (though possibly multiple output edges.)
     // This is useful because it may be treated as a single tile.
-    // Returns a list of objects with three keys:
+    // Returns a list of objects with these keys:
     // * tiles = A QVariantList of tiles contained within the connected component
     // * vertices = A QVariantList of vertices (VideoNodes) contained within the connected component
     // * edges = A QVariantList of edges contained within the connected component
@@ -49,6 +48,9 @@ public slots:
     // * inputPorts = A QVariantList of QVariantMaps of {vertex, input}
     // * outputNode = The output VideoNode
     QVariantList selectedConnectedComponents();
+
+    // Finds all tiles that are connected by frozen edges to the original tile set
+    QVariantList frozenConnectedComponents(QVariantList tiles);
 
     // Finds all tiles in between tile1 and tile2
     // Returns a QVariantList of tiles

--- a/src/View.h
+++ b/src/View.h
@@ -33,6 +33,7 @@ public slots:
     void addToSelection(QVariantList tiles);
     void removeFromSelection(QVariantList tiles);
     void toggleSelection(QVariantList tiles);
+    void ensureSelected(QVariantList tiles);
     QVariantList selection();
 
     // Finds the connected components of the selection


### PR DESCRIPTION
Open issues:
- You can still add things between the placeholders. 
- You can't delete anything that's frozen (good)... in fact you can't delete anything while any frozen block is selected (bad)
- The existing AutoDJ code was a bit messy. After this groundwork is out of the way I can go back and clean it up to make it easier to modify.