### PR TITLE
#100: Replace gl_FragColor with fragColor

### DIFF
--- a/resources/library/effects/yuvchansep.glsl
+++ b/resources/library/effects/yuvchansep.glsl
@@ -27,5 +27,5 @@ void main(void) {
     //float a_out = 1. - (1. - rgb.r) * (1. - rgb.g) * (1. - rgb.b);
     float a_out = yImage.a;
 
-    gl_FragColor = premultiply(vec4(rgb, a_out));
+    fragColor = premultiply(vec4(rgb, a_out));
 }


### PR DESCRIPTION
This shader works on my computer (Ubuntu 16.04, GLSL 1.30?), but I had seen this shader and a few others (`solitaire`?) fail on the gaming laptop.

We should probably use the CLI to audit all of the GLSL on the newest OpenGL.