### PR TITLE
Drop external content

### DIFF
--- a/resources/qml/Graph.qml
+++ b/resources/qml/Graph.qml
@@ -4,10 +4,11 @@ import QtQuick.Controls 1.4
 import radiance 1.0
 
 Item {
+    id: graph
     property alias model: view.model
     property alias view: view
-    property alias currentOutputName: viewWrapper.currentOutputName
-    property alias lastClickedTile: viewWrapper.lastClickedTile
+    property var registry
+    property var lastClickedTile
     Layout.fillWidth: true;
     Layout.fillHeight: true;
 
@@ -41,8 +42,7 @@ Item {
 
         Item {
             id: viewWrapper
-            property var lastClickedTile
-            property string currentOutputName: ""
+            property var graph: graph
             width: Math.max(view.width * view.scale + 400, flickable.width)
             height: Math.max(view.height * view.scale + 400, flickable.height)
 

--- a/resources/qml/TileDropArea.qml
+++ b/resources/qml/TileDropArea.qml
@@ -76,6 +76,9 @@ DropArea {
             var graph = parent.parent.graph;
             var model = parent.model;
             var url = drop.urls[0];
+            if (url.startsWith("file://")) {
+                url = url.slice(7);
+            }
             var videoNode = graph.registry.createFromFile(defaultContext, url);
             model.addVideoNode(videoNode);
             if (videoNode) Qt.callLater(function() {

--- a/resources/qml/TileDropArea.qml
+++ b/resources/qml/TileDropArea.qml
@@ -26,8 +26,6 @@ DropArea {
     x: posX - width / 2
     y: posY
 
-    keys: [ "videonode" ]
-
     ShaderEffect {
         id: dropRectangle
         property color highlightColor: RadianceStyle.dropTargetColor
@@ -67,5 +65,31 @@ DropArea {
                 }
             }
         ]
+    }
+
+    onDropped: {
+        if (drop.urls) {
+            var graph = parent.parent.graph;
+            var model = parent.model;
+            console.log("Graph is " + graph);
+            var url = drop.urls[0];
+            var videoNode = graph.registry.createFromFile(defaultContext, url);
+            model.addVideoNode(videoNode);
+            if (videoNode) Qt.callLater(function() {
+                var fn = fromNode;
+                var tn = toNode;
+                var ti = toInput;
+
+                if (fn !== null && tn !== null) model.removeEdge(fn, tn, ti);
+
+                if (fn !== null && videoNode.inputCount != 0) {
+                    model.addEdge(fn, videoNode, 0);
+                }
+                if (tn !== null) {
+                    model.addEdge(videoNode, tn, ti);
+                }
+                model.flush();
+            });
+        }
     }
 }

--- a/resources/qml/TileDropArea.qml
+++ b/resources/qml/TileDropArea.qml
@@ -69,9 +69,12 @@ DropArea {
 
     onDropped: {
         if (drop.urls) {
+            // Handle dropping of external content.
+            // TODO: I am annoyed that this is handled in a separate place from
+            // drag/drop of internal content (i.e. selected tiles) using largely duplicated code.
+            // (That code is in dragDrop in VideoNodeTile.qml)
             var graph = parent.parent.graph;
             var model = parent.model;
-            console.log("Graph is " + graph);
             var url = drop.urls[0];
             var videoNode = graph.registry.createFromFile(defaultContext, url);
             model.addVideoNode(videoNode);

--- a/resources/qml/VideoNodeTile.qml
+++ b/resources/qml/VideoNodeTile.qml
@@ -88,8 +88,6 @@ BaseVideoNodeTile {
     Drag.keys: [ "videonode" ]
     Drag.hotSpot: Qt.point(width / 2, height / 2)
     Drag.active: dragArea.drag.active
-    //Drag.dragType: Drag.Automatic
-    //Drag.supportedActions: Qt.CopyAction
 
     states: [
         State {
@@ -127,7 +125,6 @@ BaseVideoNodeTile {
         for (var i=0; i<dragCC.tiles.length; i++) {
             dragCC.tiles[i].dragging = true;
         }
-        Drag.mimeData = {"text/plain": "hello, world!"};
     }
 
     function dragDrop() {

--- a/resources/qml/VideoNodeTile.qml
+++ b/resources/qml/VideoNodeTile.qml
@@ -248,8 +248,8 @@ BaseVideoNodeTile {
     function selectMe() {
         var modifiers = Controls.keyboardModifiers();
         var tiles = [tile];
-        if (modifiers & Qt.ShiftModifier && view.parent.lastClickedTile) {
-            tiles = view.tilesBetween(view.parent.lastClickedTile, tile);
+        if (modifiers & Qt.ShiftModifier && view.parent.graph.lastClickedTile) {
+            tiles = view.tilesBetween(view.parent.graph.lastClickedTile, tile);
             if (tiles.length == 0) tiles = [tile];
         }
         if (modifiers & Qt.ControlModifier) {
@@ -259,7 +259,7 @@ BaseVideoNodeTile {
         } else {
             view.select(tiles);
         }
-        view.parent.lastClickedTile = tile;
+        view.parent.graph.lastClickedTile = tile;
     }
 
     KeyNavigation.tab: tab || null;

--- a/resources/qml/VideoNodeTile.qml
+++ b/resources/qml/VideoNodeTile.qml
@@ -87,7 +87,9 @@ BaseVideoNodeTile {
 
     Drag.keys: [ "videonode" ]
     Drag.hotSpot: Qt.point(width / 2, height / 2)
-    Drag.active: dragArea.drag.active;
+    Drag.active: dragArea.drag.active
+    //Drag.dragType: Drag.Automatic
+    //Drag.supportedActions: Qt.CopyAction
 
     states: [
         State {
@@ -125,6 +127,7 @@ BaseVideoNodeTile {
         for (var i=0; i<dragCC.tiles.length; i++) {
             dragCC.tiles[i].dragging = true;
         }
+        Drag.mimeData = {"text/plain": "hello, world!"};
     }
 
     function dragDrop() {

--- a/resources/qml/application.qml
+++ b/resources/qml/application.qml
@@ -61,6 +61,7 @@ ApplicationWindow {
             Graph {
                 id: graph
                 model: model
+                registry: registry
                 anchors.fill: parent
             }
 

--- a/src/MovieNode.cpp
+++ b/src/MovieNode.cpp
@@ -660,6 +660,7 @@ VideoNodeSP *MovieNode::deserialize(Context *context, QJsonObject obj) {
 }
 
 bool MovieNode::canCreateFromFile(QString filename) {
+    return true;
     QStringList extensions({".mp4", ".mkv"});
     for (auto extension = extensions.begin(); extension != extensions.end(); extension++) {
         if (filename.endsWith(*extension, Qt::CaseInsensitive)) return true;

--- a/src/MovieNode.h
+++ b/src/MovieNode.h
@@ -187,6 +187,7 @@ protected:
     QSize m_videoSize;
     QSize m_chainSize;
     QSharedPointer<MovieNodeRenderState> m_state;
+    QString m_lastError;
 
 protected slots:
     void onEvent();

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -83,7 +83,6 @@ bool Registry::canCreateFromFile(QString filename) {
 }
 
 VideoNodeSP *Registry::createFromFile(Context *context, QString filename) {
-    qDebug() << "Registry: create from file" << filename;
     for (auto f = m_factories.begin(); f != m_factories.end(); f++) {
         if (f->canCreateFromFile(Paths::expandLibraryPath(filename))) {
             return f->fromFile(context, filename);

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -21,14 +21,14 @@ Registry::Registry()
     // This can be done with some black magic fuckery in the future
     registerType<EffectNode>();
     registerType<ImageNode>();
-#ifdef USE_MPV
-    registerType<MovieNode>();
-#endif
     registerType<ScreenOutputNode>();
     registerType<FFmpegOutputNode>();
     registerType<PlaceholderNode>();
     registerType<ConsoleOutputNode>();
     registerType<LightOutputNode>();
+#ifdef USE_MPV
+    registerType<MovieNode>();
+#endif
 
     m_library = new Library(this);
     m_library->setParent(this);

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -83,6 +83,7 @@ bool Registry::canCreateFromFile(QString filename) {
 }
 
 VideoNodeSP *Registry::createFromFile(Context *context, QString filename) {
+    qDebug() << "Registry: create from file" << filename;
     for (auto f = m_factories.begin(); f != m_factories.end(); f++) {
         if (f->canCreateFromFile(Paths::expandLibraryPath(filename))) {
             return f->fromFile(context, filename);

--- a/src/View.h
+++ b/src/View.h
@@ -3,6 +3,8 @@
 #include "Model.h"
 #include "Controls.h"
 
+class Registry;
+
 struct Child {
     VideoNodeSP *videoNode;
     BaseVideoNodeTile *item;
@@ -67,7 +69,7 @@ public slots:
 protected:
     // m_model needs to be a ModelSP since there are QML properties that fetch it
     // This one ModelSP pointer can be shared by all of the UI and not cause problems
-    ModelSP *m_model;
+    ModelSP *m_model{};
     QMap<QString, QString> m_delegates;
     QList<Child> m_children;
     QList<QQuickItem *> m_dropAreas;


### PR DESCRIPTION
This patch allows the user to drag and drop content from a web browser or their mouse clicky file shower app straight into Radiance.

Tested with Youtube videos, images from the web (they load with MPV :woman_shrugging:), images locally, and shaders locally.

To make this change, I had to make MPV claim that it can handle any files (which is not entirely wrong.)

Does not work with `.json` model files yet (MPV tries and fails to load them).

I spent a bit of time trying to get drag and drop *out* of Radiance to work, but navigating the transition from an "internal" drag to an "external" one is tricky, so that behavior isn't in. Copy and paste is likely to be a better solution anyway.