### PR TITLE
Fix LightOutputNode crash

### DIFF
--- a/src/QQuickLightOutputPreview.cpp
+++ b/src/QQuickLightOutputPreview.cpp
@@ -114,8 +114,8 @@ private:
     QSharedPointer<QOpenGLShaderProgram> loadLightShader() {
         auto vertexString = QString{
             "#version 150\n"
-            "attribute vec2 posAttr;\n"
-            "attribute vec4 colAttr;\n"
+            "in vec2 posAttr;\n"
+            "in vec4 colAttr;\n"
             "out vec4 col;\n"
             "uniform mat4 mvp;\n"
             "uniform float dpr;\n"


### PR DESCRIPTION
I don't know anything about QT, but this change seems to have fixed the following error:
```qml: Graph changed! +1 -0 vertices, +0 -0 edges
QOpenGLShader::compile(Vertex): 0(2) : error C7555: 'attribute' is deprecated, use 'in/out' instead
0(3) : error C7555: 'attribute' is deprecated, use 'in/out' instead

*** Problematic Vertex shader source code ***
#version 150
#define lowp
#define mediump
#define highp
#line 1
attribute vec2 posAttr;
attribute vec4 colAttr;
out vec4 col;
uniform mat4 mvp;
uniform float dpr;
void main() {
   col = colAttr;
   gl_Position = mvp * vec4(posAttr, 0., 1.);
   gl_PointSize = 10 * dpr;
}

***
Could not compile vertex shader
Segmentation fault (core dumped)
```