### PR TITLE
Fixes for Qt5.14

### DIFF
--- a/src/Library.cpp
+++ b/src/Library.cpp
@@ -98,7 +98,8 @@ void Library::populate(LibraryItem *item, QString currentDirectory = ".") {
     QDir userDir(Paths::userLibrary() + "/" + currentDirectory);
     auto systemLs = systemDir.entryList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
     auto userLs = userDir.entryList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
-    auto ls = (systemLs + userLs).toSet().toList();
+    auto lsList = systemLs + userLs;
+    auto ls = QSet<QString>(lsList.begin(), lsList.end()).values();
     ls.sort(Qt::CaseInsensitive);
     for (auto f = ls.begin(); f != ls.end(); f++) {
         auto path = currentDirectory + "/" + *f;

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -361,8 +361,8 @@ void Model::flush() {
 
     // Compute the changeset
     {
-        auto v = QSet<VideoNodeSP *>::fromList(m_vertices);
-        auto v4r = QSet<VideoNodeSP *>::fromList(m_verticesForRendering);
+        auto v = QSet<VideoNodeSP *>(m_vertices.begin(), m_vertices.end());
+        auto v4r = QSet<VideoNodeSP *>(m_verticesForRendering.begin(), m_verticesForRendering.end());
         // TODO Can't use QSet without implementing qHash
         //auto e = QSet<Edge>::fromList(m_edges);
         //auto e4r = QSet<Edge>::fromList(m_edgesForRendering);

--- a/src/OutputWindow.cpp
+++ b/src/OutputWindow.cpp
@@ -2,6 +2,7 @@
 
 #include <QScreen>
 #include <QGuiApplication>
+#include <QKeyEvent>
 
 // OutputWindow
 

--- a/src/QmlSharedPointer.h
+++ b/src/QmlSharedPointer.h
@@ -102,11 +102,7 @@ private:
             QMetaObject::disconnect(data(), i, this, i);
         }
     }
-    static const QMetaObject *gen_superdata();
     static const QByteArrayData *gen_stringdata();
-    static const uint *gen_data();
-    static const QMetaObject::SuperData *gen_relatedMetaObjects();
-    static void *gen_extradata();
     static void findAndActivateSignal(QObject *_o, int _id, void **_a);
 
 public:
@@ -287,12 +283,6 @@ template <typename T, typename B> void QmlSharedPointer<T, B>::qt_static_metacal
 }
 
 template<typename T, typename B>
-const QMetaObject *QmlSharedPointer<T, B>::gen_superdata()
-{
-    return &B::staticMetaObject;
-}
-
-template<typename T, typename B>
 const QByteArrayData *QmlSharedPointer<T, B>::gen_stringdata()
 {
     // The MOC always places the strings right after the QByteArrayDatas,
@@ -330,29 +320,11 @@ const QByteArrayData *QmlSharedPointer<T, B>::gen_stringdata()
     return new_stringdata;
 }
 
-template<typename T, typename B>
-const uint *QmlSharedPointer<T, B>::gen_data()
-{
-    return T::staticMetaObject.d.data;
-}
-
-template<typename T, typename B>
-const QMetaObject::SuperData *QmlSharedPointer<T, B>::gen_relatedMetaObjects()
-{
-    return T::staticMetaObject.d.relatedMetaObjects;
-}
-
-template<typename T, typename B>
-void *QmlSharedPointer<T, B>::gen_extradata()
-{
-    return T::staticMetaObject.d.extradata;
-}
-
 template<typename T, typename B> const QMetaObject QmlSharedPointer<T, B>::staticMetaObject = { {
-    QmlSharedPointer<T, B>::gen_superdata(),
+    &B::staticMetaObject,
     QmlSharedPointer<T, B>::gen_stringdata(),
-    QmlSharedPointer<T, B>::gen_data(),
+    T::staticMetaObject.d.data,
     QmlSharedPointer<T, B>::qt_static_metacall,
-    QmlSharedPointer<T, B>::gen_relatedMetaObjects(),
-    QmlSharedPointer<T, B>::gen_extradata(),
+    T::staticMetaObject.d.relatedMetaObjects,
+    T::staticMetaObject.d.extradata,
 } };

--- a/src/QmlSharedPointer.h
+++ b/src/QmlSharedPointer.h
@@ -105,7 +105,7 @@ private:
     static const QMetaObject *gen_superdata();
     static const QByteArrayData *gen_stringdata();
     static const uint *gen_data();
-    static const QMetaObject * const *gen_relatedMetaObjects();
+    static const QMetaObject::SuperData *gen_relatedMetaObjects();
     static void *gen_extradata();
     static void findAndActivateSignal(QObject *_o, int _id, void **_a);
 
@@ -307,7 +307,7 @@ const QByteArrayData *QmlSharedPointer<T, B>::gen_stringdata()
     static QByteArrayData new_stringdata[MAX_N_STRINGS];
 
     for (int i=0; i<MAX_N_STRINGS; i++) {
-        new_stringdata[i].ref.atomic.store(-1); // Don't attempt to free
+        new_stringdata[i].ref.atomic.storeRelaxed(-1); // Don't attempt to free
     }
 
     for (int i=0; i<n_strings; i++) {
@@ -337,7 +337,7 @@ const uint *QmlSharedPointer<T, B>::gen_data()
 }
 
 template<typename T, typename B>
-const QMetaObject * const *QmlSharedPointer<T, B>::gen_relatedMetaObjects()
+const QMetaObject::SuperData *QmlSharedPointer<T, B>::gen_relatedMetaObjects()
 {
     return T::staticMetaObject.d.relatedMetaObjects;
 }

--- a/src/View.cpp
+++ b/src/View.cpp
@@ -668,7 +668,7 @@ QVariantList View::selectedConnectedComponents() {
     QSet<VideoNodeSP *> selectedVerticesSet;
     QVector<VideoNodeSP *> selectedVertices;
     {
-        auto vSet = QSet<VideoNodeSP *>::fromList(vertices);
+        auto vSet = QSet<VideoNodeSP *>(vertices.begin(), vertices.end());
         for (int i=0; i<m_children.count(); i++) {
             if (m_selection.contains(m_children.at(i).item)
              && vSet.contains(m_children.at(i).videoNode)) {


### PR DESCRIPTION
Some of the private API we are using changed in Qt 5.14. This patch makes `QmlSharedPointer` compatible with 5.14 and older by removing an unnecessary layer of wrapping we were doing. It also fixes some deprecated set handling in other parts of the code. It addresses issue #110.